### PR TITLE
feat(web): resizable sidebar with collapse button

### DIFF
--- a/src/web/components/AppShell.tsx
+++ b/src/web/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Moon, Search, Sun } from "lucide-react";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Toaster } from "sonner";
 
 import { Separator } from "@/components/ui/separator";
@@ -26,6 +26,51 @@ const VIEW_KEYS = [
 	"/completed",
 	"/deleted",
 ];
+
+function ResizeHandle() {
+	const ui = useUi();
+	const handleRef = useRef<HTMLDivElement>(null);
+	const startXRef = useRef(0);
+	const startWidthRef = useRef(0);
+
+	useEffect(() => {
+		const el = handleRef.current;
+		if (!el) return;
+
+		const onMouseDown = (e: MouseEvent) => {
+			e.preventDefault();
+			startXRef.current = e.clientX;
+			startWidthRef.current = ui.sidebarWidth;
+			document.body.style.userSelect = "none";
+			document.body.style.cursor = "col-resize";
+
+			const onMouseMove = (e: MouseEvent) => {
+				const delta = e.clientX - startXRef.current;
+				ui.setSidebarWidth(startWidthRef.current + delta);
+			};
+
+			const onMouseUp = () => {
+				document.body.style.userSelect = "";
+				document.body.style.cursor = "";
+				document.removeEventListener("mousemove", onMouseMove);
+				document.removeEventListener("mouseup", onMouseUp);
+			};
+
+			document.addEventListener("mousemove", onMouseMove);
+			document.addEventListener("mouseup", onMouseUp);
+		};
+
+		el.addEventListener("mousedown", onMouseDown);
+		return () => el.removeEventListener("mousedown", onMouseDown);
+	}, [ui]);
+
+	return (
+		<div
+			ref={handleRef}
+			className="w-1 shrink-0 cursor-col-resize bg-border transition-colors hover:bg-accent active:bg-accent"
+		/>
+	);
+}
 
 export function AppShell() {
 	const ui = useUi();
@@ -62,6 +107,7 @@ export function AppShell() {
 	return (
 		<div className="flex h-full">
 			<Sidebar />
+			{ui.sidebarVisible && !ui.sidebarCollapsed && <ResizeHandle />}
 			<div className="flex min-w-0 flex-1 flex-col">
 				<header className="flex items-center gap-2 px-4 py-2">
 					<Search className="h-4 w-4 text-muted" />

--- a/src/web/components/HelpDialog.tsx
+++ b/src/web/components/HelpDialog.tsx
@@ -16,7 +16,7 @@ const SECTIONS: Array<[string, Array<[string, string]>]> = [
 			["k / ↑", "Move up"],
 			["g / G", "First / last task"],
 			["space", "Expand or collapse subtasks"],
-[\"\\\\\", \"Show / hide sidebar\"],
+			["\\", "Show / hide sidebar"],
 			["/", "Search tasks"],
 			["⌘K", "Command palette"],
 			["1–8", "Switch view (Today, Inbox, Upcoming…)"],

--- a/src/web/components/HelpDialog.tsx
+++ b/src/web/components/HelpDialog.tsx
@@ -16,7 +16,7 @@ const SECTIONS: Array<[string, Array<[string, string]>]> = [
 			["k / ↑", "Move up"],
 			["g / G", "First / last task"],
 			["space", "Expand or collapse subtasks"],
-			["\\", "Toggle sidebar"],
+[\"\\\\\", \"Show / hide sidebar\"],
 			["/", "Search tasks"],
 			["⌘K", "Command palette"],
 			["1–8", "Switch view (Today, Inbox, Upcoming…)"],

--- a/src/web/components/Sidebar.tsx
+++ b/src/web/components/Sidebar.tsx
@@ -4,6 +4,8 @@ import {
 	Bell,
 	CalendarDays,
 	CheckCircle2,
+	ChevronLeft,
+	ChevronRight,
 	Flag,
 	Inbox,
 	Moon,
@@ -168,11 +170,43 @@ export function Sidebar() {
 		);
 	}
 
+	// Collapsed strip with expand button
+	if (ui.sidebarCollapsed) {
+		return (
+			<aside
+				style={{ width: 40 }}
+				className="flex shrink-0 flex-col items-center border-r border-border bg-surface/50 py-2"
+			>
+				<button
+					type="button"
+					aria-label="Expand sidebar"
+					onClick={() => ui.toggleSidebarCollapsed()}
+					className="flex h-7 w-7 items-center justify-center rounded-md text-muted hover:bg-surface hover:text-foreground"
+				>
+					<ChevronRight className="h-4 w-4" />
+				</button>
+			</aside>
+		);
+	}
+
 	if (!ui.sidebarVisible) return null;
 
 	const iconClass = "h-4 w-4 shrink-0";
 	return (
-		<aside className="flex w-60 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border bg-surface/50 p-2">
+		<aside
+			style={{ width: ui.sidebarWidth }}
+			className="flex shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border bg-surface/50 p-2"
+		>
+			<div className="mb-1 flex items-center justify-end px-1">
+				<button
+					type="button"
+					aria-label="Collapse sidebar"
+					onClick={() => ui.toggleSidebarCollapsed()}
+					className="flex h-6 w-6 items-center justify-center rounded-md text-muted hover:bg-surface hover:text-foreground"
+				>
+					<ChevronLeft className="h-4 w-4" />
+				</button>
+			</div>
 			<NavLink
 				to="/today"
 				icon={<Sun className={iconClass} />}

--- a/src/web/state/ui.tsx
+++ b/src/web/state/ui.tsx
@@ -11,6 +11,34 @@ export type ProjectDialogState =
 	| { mode: "create" }
 	| { mode: "edit"; project: Project };
 
+const MIN_SIDEBAR_WIDTH = 160;
+const MAX_SIDEBAR_WIDTH = 480;
+const DEFAULT_SIDEBAR_WIDTH = 240;
+
+function readStoredNumber(key: string, fallback: number): number {
+	try {
+		const stored = localStorage.getItem(key);
+		if (stored) {
+			const parsed = Number.parseInt(stored, 10);
+			if (!Number.isNaN(parsed)) return parsed;
+		}
+	} catch {
+		// localStorage unavailable
+	}
+	return fallback;
+}
+
+function readStoredBool(key: string, fallback: boolean): boolean {
+	try {
+		const stored = localStorage.getItem(key);
+		if (stored === "true") return true;
+		if (stored === "false") return false;
+	} catch {
+		// localStorage unavailable
+	}
+	return fallback;
+}
+
 type UiState = {
 	quickAdd: QuickAddOptions | null;
 	openQuickAdd: (options?: QuickAddOptions) => void;
@@ -32,6 +60,12 @@ type UiState = {
 
 	sidebarVisible: boolean;
 	toggleSidebar: () => void;
+
+	sidebarWidth: number;
+	setSidebarWidth: (width: number) => void;
+
+	sidebarCollapsed: boolean;
+	toggleSidebarCollapsed: () => void;
 
 	search: string;
 	setSearch: (value: string) => void;
@@ -57,11 +91,29 @@ export function UiProvider({ children }: { children: React.ReactNode }) {
 		if (stored === "light" || stored === "dark") return stored;
 		return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
 	});
+	const [sidebarWidth, setSidebarWidthRaw] = useState(() =>
+		readStoredNumber("sidebarWidth", DEFAULT_SIDEBAR_WIDTH),
+	);
+	const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
+		readStoredBool("sidebarCollapsed", false),
+	);
 
 	useEffect(() => {
 		document.documentElement.classList.toggle("light", theme === "light");
 		localStorage.setItem("theme", theme);
 	}, [theme]);
+
+	useEffect(() => {
+		localStorage.setItem("sidebarWidth", String(sidebarWidth));
+	}, [sidebarWidth]);
+
+	useEffect(() => {
+		localStorage.setItem("sidebarCollapsed", String(sidebarCollapsed));
+	}, [sidebarCollapsed]);
+
+	const setSidebarWidth = (width: number) => {
+		setSidebarWidthRaw(Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, Math.round(width))));
+	};
 
 	const value = useMemo<UiState>(
 		() => ({
@@ -80,6 +132,10 @@ export function UiProvider({ children }: { children: React.ReactNode }) {
 			setPaletteOpen,
 			sidebarVisible,
 			toggleSidebar: () => setSidebarVisible((v) => !v),
+			sidebarWidth,
+			setSidebarWidth,
+			sidebarCollapsed,
+			toggleSidebarCollapsed: () => setSidebarCollapsed((v) => !v),
 			search,
 			setSearch,
 			theme,
@@ -92,6 +148,8 @@ export function UiProvider({ children }: { children: React.ReactNode }) {
 			helpOpen,
 			paletteOpen,
 			sidebarVisible,
+			sidebarWidth,
+			sidebarCollapsed,
 			search,
 			theme,
 		],


### PR DESCRIPTION
Closes #458

## Summary

Adds two sidebar UX improvements to the web app:

1. **Drag-to-resize** — a draggable 4px handle between the sidebar and content area. Dragging left/right resizes the sidebar between 160px (min) and 480px (max). Width persists in localStorage.
2. **Collapse/expand button** — a ChevronLeft/ChevronRight button that collapses the sidebar to a 40px icon strip or expands it back to the last remembered width.

The existing `\` hotkey still toggles full sidebar visibility (hide/show).

## Changes

| File | Change |
|---|---|
| `src/web/state/ui.tsx` | Add `sidebarWidth` (persisted, 160–480px) and `sidebarCollapsed` (persisted) state with localStorage persistence |
| `src/web/components/Sidebar.tsx` | Dynamic width via `style={{ width }}`, collapsed strip view, collapse/expand chevron buttons |
| `src/web/components/AppShell.tsx` | Add `ResizeHandle` component with mouse drag logic, rendered between sidebar and content |
| `src/web/components/HelpDialog.tsx` | Update `\` shortcut description |

## Testing

```bash
bun run web:dev
```

Manual verification:
- [ ] Drag the resize handle right → sidebar widens (up to 480px)
- [ ] Drag the resize handle left → sidebar narrows (down to 160px)
- [ ] Click collapse chevron → sidebar collapses to icon strip
- [ ] Click expand chevron (in collapsed strip) → sidebar restores to previous width
- [ ] Press `\` → sidebar fully hides
- [ ] Press `\` again → sidebar reappears
- [ ] Refresh page → width and collapse state persist
- [ ] Handle shows `col-resize` cursor on hover
- [ ] No text selection during drag