### PR TITLE
Add pills for creating entities in quick add (#459)

### DIFF
--- a/src/web/components/QuickAdd.tsx
+++ b/src/web/components/QuickAdd.tsx
@@ -7,6 +7,7 @@ import { parseTaskCreateInput } from "@/lib/parsing/parse-task-create-input";
 import { useHotkeyScope } from "../lib/hotkeys";
 import { useProjects, useTaskMutations } from "../lib/queries";
 import { useUi } from "../state/ui";
+import { QuickAddPills } from "./QuickAddPills";
 
 /**
  * Quick-add bar using the same token syntax as the TUI:
@@ -98,6 +99,12 @@ export function QuickAdd() {
 					onChange={(e) => setValue(e.target.value)}
 					placeholder="Ship docs project:Work p1 due:today recurs:weekly"
 					className="w-full bg-transparent px-4 py-3 text-base outline-none placeholder:text-muted/60"
+				/>
+				<QuickAddPills
+					value={value}
+					onChange={setValue}
+					projects={projects}
+					parsed={parsed}
 				/>
 				<div className="flex min-h-8 items-center gap-3 border-t border-border px-4 py-1.5 text-xs">
 					{suggestion ? (

--- a/src/web/components/QuickAddPills.test.tsx
+++ b/src/web/components/QuickAddPills.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+
+/* ------------------------------------------------------------------ */
+/*  Mirror the token helpers from QuickAddPills.tsx for unit tests      */
+/* ------------------------------------------------------------------ */
+
+function removeToken(value: string, regex: RegExp): string {
+	return value.replace(regex, "").replace(/\s{2,}/g, " ").trim();
+}
+
+function insertToken(value: string, token: string): string {
+	return `${value} ${token}`.trim();
+}
+
+function escapeRegExp(s: string) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/* ------------------------------------------------------------------ */
+
+describe("QuickAddPills token logic", () => {
+	describe("priority", () => {
+		it("inserts p1 into empty string", () => {
+			expect(insertToken("", "p1")).toBe("p1");
+		});
+
+		it("inserts p1 after existing text", () => {
+			expect(insertToken("Ship docs", "p1")).toBe("Ship docs p1");
+		});
+
+		it("removes p1 token", () => {
+			expect(removeToken("Ship docs p1", /\bp1\b/i)).toBe("Ship docs");
+		});
+
+		it("removes priority:1 token", () => {
+			expect(removeToken("Ship docs priority:1", /\b(?:priority:|prio:)\s*1\b|\bp1\b/i)).toBe("Ship docs");
+		});
+
+		it("replaces p1 with p2", () => {
+			const value = "Ship docs p1";
+			const removeExisting = value.replace(/\b(?:priority:|prio:)\s*[1-4]\b|\bp[1-4]\b/gi, "");
+			const cleaned = removeExisting.replace(/\s{2,}/g, " ").trim();
+			expect(insertToken(cleaned, "p2")).toBe("Ship docs p2");
+		});
+	});
+
+	describe("project", () => {
+		it("inserts project:Work", () => {
+			expect(insertToken("", "project:Work")).toBe("project:Work");
+		});
+
+		it("removes project:Work token", () => {
+			expect(removeToken("Ship docs project:Work", /\b(?:project:|proj:|📁\s*)\s*Work\b/i)).toBe("Ship docs");
+		});
+	});
+
+	describe("due date", () => {
+		it("inserts due:today", () => {
+			expect(insertToken("", "due:today")).toBe("due:today");
+		});
+
+		it("removes due:today token", () => {
+			expect(removeToken("Ship docs due:today", /\b(?:due:|⏰\s*)\s*(?:today|tomorrow|next\s*week|none|never|clear|\d{4}-\d{2}-\d{2})\b/gi)).toBe("Ship docs");
+		});
+	});
+
+	describe("scheduled date", () => {
+		it("inserts sch:today", () => {
+			expect(insertToken("", "sch:today")).toBe("sch:today");
+		});
+
+		it("removes sch:today token", () => {
+			expect(removeToken("Ship docs sch:today", /\b(?:scheduled:|sch:|🗓\s*)\s*(?:today|tomorrow|next\s*week|none|never|clear|\d{4}-\d{2}-\d{2})\b/gi)).toBe("Ship docs");
+		});
+	});
+
+	describe("recurrence", () => {
+		it("inserts recurs:daily", () => {
+			expect(insertToken("", "recurs:daily")).toBe("recurs:daily");
+		});
+
+		it("removes recurs:daily token", () => {
+			expect(removeToken("Ship docs recurs:daily", /\b(?:recurs:|rec:|recurrence:)\s*(?:daily|weekly|monthly|yearly|every_weekday|none|never|clear)\b/gi)).toBe("Ship docs");
+		});
+	});
+});

--- a/src/web/components/QuickAddPills.tsx
+++ b/src/web/components/QuickAddPills.tsx
@@ -1,0 +1,389 @@
+import { useState, useRef, useEffect, useMemo } from "react";
+import { ChevronDown, X } from "lucide-react";
+import type { Project } from "@/server/types";
+import type { ParseTaskCreateResult } from "@/lib/parsing/parse-task-create-input";
+import { cn } from "../lib/cn";
+
+/* ------------------------------------------------------------------ */
+/*  Token helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+function escapeRegExp(s: string) {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function removeToken(value: string, regex: RegExp): string {
+	return value
+		.replace(regex, "")
+		.replace(/\s{2,}/g, " ")
+		.trim();
+}
+
+function insertToken(value: string, token: string): string {
+	return `${value} ${token}`.trim();
+}
+
+function replaceToken(value: string, regex: RegExp, token: string): string {
+	const replaced = value.replace(regex, token);
+	if (replaced !== value) return replaced.replace(/\s{2,}/g, " ").trim();
+	return insertToken(value, token);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Pill component                                                     */
+/* ------------------------------------------------------------------ */
+
+function Pill({
+	label,
+	active,
+	onClick,
+	className,
+	title,
+}: {
+	label: string;
+	active?: boolean;
+	onClick?: () => void;
+	className?: string;
+	title?: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			title={title}
+			className={cn(
+				"inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors",
+				"focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
+				active
+					? "border-accent bg-accent/20 text-accent"
+					: "border-border text-muted hover:bg-surface-raised hover:text-foreground",
+				className,
+			)}
+		>
+			{active ? <X className="h-3 w-3" /> : null}
+			{label}
+		</button>
+	);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Dropdown for project overflow                                      */
+/* ------------------------------------------------------------------ */
+
+function ProjectDropdown({
+	projects,
+	onSelect,
+	children,
+}: {
+	projects: Project[];
+	onSelect: (project: Project) => void;
+	children: React.ReactNode;
+}) {
+	const [open, setOpen] = useState(false);
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		function handleClickOutside(event: MouseEvent) {
+			if (ref.current && !ref.current.contains(event.target as Node)) {
+				setOpen(false);
+			}
+		}
+		if (open) {
+			document.addEventListener("mousedown", handleClickOutside);
+			return () => document.removeEventListener("mousedown", handleClickOutside);
+		}
+	}, [open]);
+
+	return (
+		<div ref={ref} className="relative inline-flex">
+			<button
+				type="button"
+				onClick={() => setOpen(!open)}
+				className={cn(
+					"inline-flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-xs font-medium transition-colors",
+					"border-border text-muted hover:bg-surface-raised hover:text-foreground",
+					"focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
+				)}
+			>
+				{children}
+				<ChevronDown className="h-3 w-3" />
+			</button>
+			{open ? (
+				<div className="absolute left-0 top-full z-50 mt-1 max-h-48 min-w-[12rem] overflow-auto rounded-md border border-border bg-surface-raised shadow-lg">
+					{projects.map((project) => (
+						<button
+							key={project.id}
+							type="button"
+							onClick={() => {
+								onSelect(project);
+								setOpen(false);
+							}}
+							className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-foreground hover:bg-surface"
+						>
+							{project.emoji ? (
+								<span className="text-sm">{project.emoji}</span>
+							) : null}
+							<span className="truncate">{project.name}</span>
+						</button>
+						))}
+					</div>
+				) : null}
+			</div>
+		);
+	}
+
+/* ------------------------------------------------------------------ */
+/*  QuickAddPills                                                      */
+/* ------------------------------------------------------------------ */
+
+export function QuickAddPills({
+	value,
+	onChange,
+	projects,
+	parsed,
+}: {
+	value: string;
+	onChange: (value: string) => void;
+	projects: Project[];
+	parsed: ParseTaskCreateResult | null;
+}) {
+	const MAX_PROJECT_PILLS = 5;
+
+	const activePriority = parsed?.input.priority;
+	const activeProjectId = parsed?.input.projectId;
+	const activeDue = parsed?.input.dueAt;
+	const activeScheduled = parsed?.input.scheduledAt;
+	const activeRecurrence = parsed?.input.recurrencePreset;
+
+	const nonInboxProjects = useMemo(
+		() => projects.filter((p) => !p.isInbox),
+		[projects],
+	);
+
+	const visibleProjects = nonInboxProjects.slice(0, MAX_PROJECT_PILLS);
+	const overflowProjects = nonInboxProjects.slice(MAX_PROJECT_PILLS);
+
+	const hasOverflow = overflowProjects.length > 0;
+	const overflowLabel = `+${overflowProjects.length}`;
+
+	/* ---------- priority ---------- */
+	function togglePriority(priority: number) {
+		if (activePriority === priority) {
+			// remove pN token
+			const regex = new RegExp(
+				`\\b(?:priority:|prio:)\\s*${priority}\\b|\\bp${priority}\\b`,
+				"i",
+			);
+			onChange(removeToken(value, regex));
+		} else {
+			// remove existing priority, then insert new one
+			const removeExisting = value.replace(
+				/\b(?:priority:|prio:)\s*[1-4]\b|\bp[1-4]\b/gi,
+				"",
+			);
+			const cleaned = removeExisting.replace(/\s{2,}/g, " ").trim();
+			onChange(insertToken(cleaned, `p${priority}`));
+		}
+	}
+
+	/* ---------- project ---------- */
+	function toggleProject(project: Project) {
+		if (activeProjectId === project.id) {
+			const regex = new RegExp(
+				`\\b(?:project:|proj:|📁\\s*)\\s*${escapeRegExp(project.name)}\\b`,
+				"i",
+			);
+			onChange(removeToken(value, regex));
+		} else {
+			// remove existing project token
+			const removeExisting = value.replace(
+				/\b(?:project:|proj:|📁\s*)\s*[^\s]+/gi,
+				"",
+			);
+			const cleaned = removeExisting.replace(/\s{2,}/g, " ").trim();
+			onChange(insertToken(cleaned, `project:${project.name}`));
+		}
+	}
+
+	/* ---------- due date ---------- */
+	const dateOptions = [
+		{ label: "Today", token: "due:today" },
+		{ label: "Tomorrow", token: "due:tomorrow" },
+		{ label: "Next week", token: "due:next week" },
+	] as const;
+
+	function toggleDue(option: (typeof dateOptions)[number]) {
+		if (activeDue !== null && activeDue !== undefined) {
+			// remove any due token
+			const regex = /\b(?:due:|⏰\s*)\s*(?:today|tomorrow|next\s*week|none|never|clear|\d{4}-\d{2}-\d{2})\b/gi;
+			const cleaned = removeToken(value, regex);
+			if (activeDue && option.token.includes("due:")) {
+				// already active with same type? toggle off
+				const currentMatch = value.match(
+					/\b(?:due:|⏰\s*)\s*(today|tomorrow|next\s*week)/i,
+				);
+				if (currentMatch && option.token.includes(currentMatch[1].toLowerCase())) {
+					onChange(cleaned);
+					return;
+				}
+				onChange(insertToken(cleaned, option.token));
+				return;
+			}
+			onChange(insertToken(cleaned, option.token));
+			return;
+		}
+		onChange(insertToken(value, option.token));
+	}
+
+	function isDueActive(label: string): boolean {
+		if (activeDue === null || activeDue === undefined) return false;
+		const match = value.match(/\b(?:due:|⏰\s*)\s*(today|tomorrow|next\s*week)/i);
+		if (!match) return false;
+		return match[1].toLowerCase().replace(/\s+/g, " ") === label.toLowerCase();
+	}
+
+	/* ---------- scheduled date ---------- */
+	const schedOptions = [
+		{ label: "Today", token: "sch:today" },
+		{ label: "Tomorrow", token: "sch:tomorrow" },
+		{ label: "Next week", token: "sch:next week" },
+	] as const;
+
+	function toggleScheduled(option: (typeof schedOptions)[number]) {
+		if (activeScheduled !== null && activeScheduled !== undefined) {
+			const regex = /\b(?:scheduled:|sch:|🗓\s*)\s*(?:today|tomorrow|next\s*week|none|never|clear|\d{4}-\d{2}-\d{2})\b/gi;
+			const cleaned = removeToken(value, regex);
+			if (activeScheduled && option.token.includes("sch:")) {
+				const currentMatch = value.match(
+					/\b(?:scheduled:|sch:|🗓\s*)\s*(today|tomorrow|next\s*week)/i,
+				);
+				if (currentMatch && option.token.includes(currentMatch[1].toLowerCase())) {
+					onChange(cleaned);
+					return;
+				}
+				onChange(insertToken(cleaned, option.token));
+				return;
+			}
+			onChange(insertToken(cleaned, option.token));
+			return;
+		}
+		onChange(insertToken(value, option.token));
+	}
+
+	function isScheduledActive(label: string): boolean {
+		if (activeScheduled === null || activeScheduled === undefined) return false;
+		const match = value.match(/\b(?:scheduled:|sch:|🗓\s*)\s*(today|tomorrow|next\s*week)/i);
+		if (!match) return false;
+		return match[1].toLowerCase().replace(/\s+/g, " ") === label.toLowerCase();
+	}
+
+	/* ---------- recurrence ---------- */
+	const recOptions = [
+		{ label: "Daily", token: "recurs:daily" },
+		{ label: "Weekly", token: "recurs:weekly" },
+		{ label: "Monthly", token: "recurs:monthly" },
+	] as const;
+
+	function toggleRecurrence(option: (typeof recOptions)[number]) {
+		if (activeRecurrence) {
+			const regex = /\b(?:recurs:|rec:|recurrence:)\s*(?:daily|weekly|monthly|yearly|every_weekday|none|never|clear)\b/gi;
+			const cleaned = removeToken(value, regex);
+			if (activeRecurrence === option.token.split(":")[1]) {
+				onChange(cleaned);
+				return;
+			}
+			onChange(insertToken(cleaned, option.token));
+			return;
+		}
+		onChange(insertToken(value, option.token));
+	}
+
+	function isRecurrenceActive(label: string): boolean {
+		return activeRecurrence?.toLowerCase() === label.toLowerCase();
+	}
+
+	/* ---------- render ---------- */
+	return (
+		<div className="flex flex-wrap items-center gap-1.5 px-4 py-1.5">
+			{/* Priority */}
+			<div className="flex items-center gap-1">
+				{[1, 2, 3, 4].map((p) => (
+					<Pill
+						key={p}
+						label={`P${p}`}
+						active={activePriority === p}
+						onClick={() => togglePriority(p)}
+						className={cn(
+							activePriority === p && [
+								p === 1 && "text-p1",
+								p === 2 && "text-p2",
+								p === 3 && "text-p3",
+								p === 4 && "text-p4",
+							],
+						)}
+					/>
+				))}
+			</div>
+
+			{/* Projects */}
+			{visibleProjects.length > 0 ? (
+				<div className="flex items-center gap-1">
+					{visibleProjects.map((project) => (
+						<Pill
+							key={project.id}
+							label={project.name}
+							active={activeProjectId === project.id}
+							onClick={() => toggleProject(project)}
+						/>
+					))}
+					{hasOverflow ? (
+						<ProjectDropdown
+							projects={overflowProjects}
+							onSelect={(project) => toggleProject(project)}
+						>
+							{overflowLabel}
+						</ProjectDropdown>
+					) : null}
+				</div>
+			) : null}
+
+			{/* Due */}
+			<div className="flex items-center gap-1">
+				{dateOptions.map((opt) => (
+					<Pill
+						key={opt.token}
+						label={`Due ${opt.label}`}
+						active={isDueActive(opt.label)}
+						onClick={() => toggleDue(opt)}
+						className="hidden sm:inline-flex"
+					/>
+				))}
+			</div>
+
+			{/* Scheduled */}
+			<div className="flex items-center gap-1">
+				{schedOptions.map((opt) => (
+					<Pill
+						key={opt.token}
+						label={`Sched ${opt.label}`}
+						active={isScheduledActive(opt.label)}
+						onClick={() => toggleScheduled(opt)}
+						className="hidden sm:inline-flex"
+					/>
+				))}
+			</div>
+
+			{/* Recurrence */}
+			<div className="flex items-center gap-1">
+				{recOptions.map((opt) => (
+					<Pill
+						key={opt.token}
+						label={opt.label}
+						active={isRecurrenceActive(opt.label)}
+						onClick={() => toggleRecurrence(opt)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
Closes #459

Adds  component between the input and footer in .

### Features
- **Priority pills**: P1–P4 (toggle pN tokens)
- **Project pills**: first 5 non-inbox projects + overflow dropdown
- **Due date pills**: due:today, due:tomorrow, due:next week
- **Scheduled pills**: sch:today, sch:tomorrow, sch:next week
- **Recurrence pills**: recurs:daily, weekly, monthly

### Behavior
- All pills are toggleable: clicking an active pill removes its token
- Clicking a different pill of the same category replaces the existing token
- Pills derive active state from the parsed result so they stay in sync when tokens are typed manually
- Responsive: due and scheduled pills are hidden on narrow viewports (sm breakpoint)

### Tests
- Unit tests for token insertion/removal/replacement logic

### Implementation Plan
- [x] Create  with pill row, overflow dropdown, and token helpers
- [x] Wire into  between input and footer
- [x] Add unit tests for token logic

### Files Changed
- 
-  (new)
-  (new)