### PR TITLE
ci: add desktop app build workflow on PR merge to main

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,0 +1,58 @@
+name: Build Desktop App
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: build-desktop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Lint & format check
+        run: bun run check
+
+      - name: Run tests
+        run: bun test
+
+      - name: Build web frontend
+        run: bun run web:build
+
+      - name: Build desktop server binary
+        run: bash scripts/build-desktop-binary.sh
+
+      - name: Build macOS app bundle
+        run: bash scripts/build-desktop-app.sh
+
+      - name: Upload desktop app artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: finish-em-macos-${{ github.sha }}
+          path: dist/finish-em.app
+          retention-days: 30
+
+      - name: Upload desktop server binary
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: finish-em-desktop-server-${{ github.sha }}
+          path: dist/desktop/finish-em
+          retention-days: 30

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "finish-em",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that builds the finish-em macOS desktop app automatically.

## Changes

- **`.github/workflows/build-desktop.yml`** — New CI workflow that triggers on push to `main` and PRs targeting `main`:
  1. Checks out the repo on `macos-latest` (required for Swift/AppKit/codesign)
  2. Installs Bun and dependencies
  3. Runs lint (`bun run check`) and tests (`bun test`)
  4. Builds the web frontend (`bun run web:build`)
  5. Builds the desktop server binary (`scripts/build-desktop-binary.sh`)
  6. Builds the macOS `.app` bundle (`scripts/build-desktop-app.sh`)
  7. On **push to main** only, uploads two artifacts:
     - `finish-em-macos-<sha>` — the full `.app` bundle
     - `finish-em-desktop-server-<sha>` — the standalone server binary
  - PR builds run lint/tests/build but skip artifact upload (downloadable artifacts are only useful after merge)

- **`package.json`** — Added `"version": "0.1.0"`. The build scripts (`build-desktop-app.sh` and `build-macos-app.sh`) read the version from `package.json` for `CFBundleShortVersionString` / `CFBundleVersion` in the `.app` Info.plist. Without this field the scripts fall back to `0.0.0`.

## Notes

- The workflow uses `concurrency` groups so only one build per branch runs at a time.
- Artifacts are retained for 30 days.
- The Swift compilation step compiles `desktop/FinishEmApp.swift` via `swiftc`, which is pre-installed on `macos-latest` runners.